### PR TITLE
fix: path normalization to prevent memory leak

### DIFF
--- a/lib/AxiosPrometheusAdapter.spec.ts
+++ b/lib/AxiosPrometheusAdapter.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { createAxiosPrometheusMiddleware } from './AxiosPrometheusAdapter';
 import client, { Registry } from 'prom-client';
 import { AxiosInstance } from 'axios';
@@ -77,11 +78,11 @@ describe('AxiosPrometheusAdapter', () => {
       },
     };
     const expectedLabels = {
-      status_code: 200,
+      status_code: '200',
       method: 'GET',
       protocol: 'https',
       host: 'localhost',
-      path: '/1234',
+      path: '/:id',
     };
 
     const response = responseInterceptor(mockResponse);
@@ -110,7 +111,7 @@ describe('AxiosPrometheusAdapter', () => {
       status: 'ECONNREFUSED',
       request: {
         ...mockRequet,
-        _currentRequest: mockRequet
+        _currentRequest: mockRequet,
       },
     };
     const expectedLabels = {
@@ -118,7 +119,7 @@ describe('AxiosPrometheusAdapter', () => {
       method: 'GET',
       protocol: 'https',
       host: 'localhost',
-      path: '/1234',
+      path: '/:id',
     };
     const response = errorInterceptor(mockError);
 
@@ -150,10 +151,10 @@ describe('AxiosPrometheusAdapter', () => {
     };
     const expectedLabels = {
       status_code: 500,
-      method: "UNKNOWN",
-      protocol: "UNKNOWN",
-      host: "UNKNOWN",
-      path: "UNKNOWN",
+      method: 'UNKNOWN',
+      protocol: 'UNKNOWN',
+      host: 'UNKNOWN',
+      path: 'UNKNOWN',
     };
     const response = errorInterceptor(mockError);
 

--- a/lib/AxiosPrometheusAdapter.ts
+++ b/lib/AxiosPrometheusAdapter.ts
@@ -2,6 +2,16 @@ import type { AxiosInstance } from 'axios';
 import type { Registry } from 'prom-client';
 import client from 'prom-client';
 
+// Path normalizer to prevent unbounded cardinality in metrics
+// Replaces dynamic segments (numbers, UUIDs, etc.) with placeholders
+const normalizePath = (path: string): string => {
+  return path
+    // Replace UUIDs (8-4-4-4-12 format)
+    .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '/:uuid')
+    // Replace any numeric IDs in paths
+    .replace(/\/[0-9]+(?=\/|$)/g, '/:id');
+};
+
 export type AxiosPrometheusAdapterConfig = {
   name: string,
   help: string,
@@ -31,13 +41,14 @@ export const createAxiosPrometheusMiddleware = (
     return config;
   });
 
+  // eslint-disable-next-line complexity
   axiosInstance.interceptors.response.use((response: any) => {
     const labels = {
-      status_code: response.status,
-      method: response.request.method,
-      protocol: response.request.protocol,
-      host: response.request.host,
-      path: response.request.path.split('?')[0],
+      status_code: response.status.toString(),
+      method: response.request.method || response.config.method?.toUpperCase() || 'UNKNOWN',
+      protocol: response.request.protocol || 'https:',
+      host: response.request.host || new URL(response.config.url || '').hostname,
+      path: normalizePath(response.request.path?.split('?')[0]),
     };
     response.config.metadata.endTimer(labels);
     return response;
@@ -45,27 +56,27 @@ export const createAxiosPrometheusMiddleware = (
     let labels;
     if (error.response) {
       labels = {
-        status_code: error.response.status,
+        status_code: error.response.status.toString(),
         method: error.response.request.method,
         protocol: error.response.request.protocol,
         host: error.response.request.host,
-        path: error.response.request.path.split('?')[0],
+        path: normalizePath(error.response.request.path.split('?')[0]),
       };
     } else if (error.request._currentRequest) {
       labels = {
-        status_code: error.status,
+        status_code: error.status.toString(),
         method: error.request._currentRequest.method,
         protocol: error.request._currentRequest.protocol,
         host: error.request._currentRequest.host,
-        path: error.request._currentRequest.path.split('?')[0],
+        path: normalizePath(error.request._currentRequest.path.split('?')[0]),
       };
     } else {
       labels = {
         status_code: 500,
-        method: "UNKNOWN",
-        protocol: "UNKNOWN",
-        host: "UNKNOWN",
-        path: "UNKNOWN",
+        method: 'UNKNOWN',
+        protocol: 'UNKNOWN',
+        host: 'UNKNOWN',
+        path: 'UNKNOWN',
       };
     }
     error.config.metadata.endTimer(labels);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.prod.json",
-    "start": "ts-node-dev examples/index.ts",
+    "start": "ts-node-dev examples/axiosRequest.ts",
     "test": "jest"
   },
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -63,34 +63,20 @@ Output:
 ...
 # HELP http_client_requests_seconds_count http_client_requests_seconds_count
 # TYPE http_client_requests_seconds_count histogram
-http_client_requests_seconds_bucket{le="0.005",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0
-http_client_requests_seconds_bucket{le="0.01",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0
-http_client_requests_seconds_bucket{le="0.025",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0
-http_client_requests_seconds_bucket{le="0.05",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0
-http_client_requests_seconds_bucket{le="0.1",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0
-http_client_requests_seconds_bucket{le="0.25",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0
-http_client_requests_seconds_bucket{le="0.5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_bucket{le="1",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_bucket{le="2.5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_bucket{le="5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_bucket{le="10",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_bucket{le="+Inf",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_sum{status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 0.257366432
-http_client_requests_seconds_count{status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/1"} 1
-http_client_requests_seconds_bucket{le="0.005",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 0
-http_client_requests_seconds_bucket{le="0.01",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 0
-http_client_requests_seconds_bucket{le="0.025",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 0
-http_client_requests_seconds_bucket{le="0.05",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 0
-http_client_requests_seconds_bucket{le="0.1",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 0
-http_client_requests_seconds_bucket{le="0.25",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_bucket{le="0.5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_bucket{le="1",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_bucket{le="2.5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_bucket{le="5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_bucket{le="10",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_bucket{le="+Inf",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
-http_client_requests_seconds_sum{status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 0.107517055
-http_client_requests_seconds_count{status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/2"} 1
+http_client_requests_seconds_bucket{le="0.005",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 0 
+http_client_requests_seconds_bucket{le="0.01",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 0 
+http_client_requests_seconds_bucket{le="0.025",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 0 
+http_client_requests_seconds_bucket{le="0.05",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 0 
+http_client_requests_seconds_bucket{le="0.1",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 0 
+http_client_requests_seconds_bucket{le="0.25",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 0 
+http_client_requests_seconds_bucket{le="0.5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 1 
+http_client_requests_seconds_bucket{le="1",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 1 
+http_client_requests_seconds_bucket{le="2.5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 2 
+http_client_requests_seconds_bucket{le="5",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 2 
+http_client_requests_seconds_bucket{le="10",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 2 
+http_client_requests_seconds_bucket{le="+Inf",status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 2 
+http_client_requests_seconds_sum{status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 1.372366292 
+http_client_requests_seconds_count{status_code="200",method="GET",protocol="https:",host="jsonplaceholder.typicode.com",path="/posts/:id"} 2
 ```
 
 ### Custom config


### PR DESCRIPTION
Path with :id url parameter previously cased increase of memory usage due to the size of the metrics output.

This PR fixes the issue by normalizing the the ids in path. E.g.: /1234556 => /:id